### PR TITLE
Changes to compile with mingw / MXE (M cross environment)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/mingw-std-threads"]
+	path = deps/mingw-std-threads
+	url = https://github.com/meganz/mingw-std-threads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(libdshowcapture)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
+find_package(CXX11 REQUIRED)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS}")
+
+if(${CMAKE_C_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+	set(CMAKE_COMPILER_IS_CLANG TRUE)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+	set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-field-initializers ${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+	set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-function -Werror-implicit-function-declaration -Wno-missing-braces -Wno-missing-field-initializers ${CMAKE_C_FLAGS} -std=gnu99 -fno-strict-aliasing")
+	
+	option(USE_LIBC++ "Use libc++ instead of libstdc++" ${APPLE})
+	if(USE_LIBC++)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+	endif()
+elseif(MSVC)
+	if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+		string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+	else()
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+	endif()
+
+	# Disable pointless constant condition warnings
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4127 /wd4201")
+endif()
+
+if(WIN32)
+	add_definitions(-DUNICODE -D_UNICODE)
+endif()
+
+if(MSVC)
+	set(CMAKE_C_FLAGS_DEBUG "/DDEBUG=1 /D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
+	set(CMAKE_CXX_FLAGS_DEBUG "/DDEBUG=1 /D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
+
+	if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")
+		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SAFESEH:NO")
+		set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /SAFESEH:NO")
+	endif()
+else()
+	if(MINGW)
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_WIN32_WINNT=0x0600 -DWINVER=0x0600")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_WIN32_WINNT=0x0600 -DWINVER=0x0600")
+	endif()
+	set(CMAKE_C_FLAGS_DEBUG "-DDEBUG=1 -D_DEBUG=1 ${CMAKE_C_FLAGS_DEBUG}")
+	set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG=1 -D_DEBUG=1 ${CMAKE_CXX_FLAGS_DEBUG}")
+endif()
+
+set(libdshowcapture_SOURCES
+	source/capture-filter.cpp
+	source/output-filter.cpp
+	source/dshowcapture.cpp
+	source/dshowencode.cpp
+	source/device.cpp
+	source/encoder.cpp
+	source/dshow-base.cpp
+	source/dshow-demux.cpp
+	source/dshow-enum.cpp
+	source/dshow-formats.cpp
+	source/dshow-media-type.cpp
+	source/dshow-encoded-device.cpp
+	source/log.cpp)
+
+set(libdshowcapture_HEADERS
+	dshowcapture.hpp
+	source/IVideoCaptureFilter.h
+	source/capture-filter.hpp
+	source/output-filter.hpp
+	source/device.hpp
+	source/encoder.hpp
+	source/dshow-base.hpp
+	source/dshow-demux.hpp
+	source/dshow-device-defs.hpp
+	source/dshow-enum.hpp
+	source/dshow-formats.hpp
+	source/dshow-media-type.hpp
+	source/log.hpp)
+
+add_library(libdshowcapture
+	${libdshowcapture_SOURCES}
+	${libdshowcapture_HEADERS})
+
+target_link_libraries(libdshowcapture
+	strmiids
+	ksuser
+	wmcodecdspuuid)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,13 @@ else()
 	set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG=1 -D_DEBUG=1 ${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
 
+if(MINGW)
+    include_directories(deps/mingw-std-threads)
+endif()
+
+include (CheckFunctionExists)
+check_function_exists (vswprintf_s HAVE_VSWPRINTF_S)
+
 set(libdshowcapture_SOURCES
 	source/capture-filter.cpp
 	source/output-filter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,12 @@ else()
 endif()
 
 if(MINGW)
-    include_directories(deps/mingw-std-threads)
+    #include_directories(deps/mingw-std-threads)
+	include (CheckSymbolExists) 
+	check_symbol_exists(MINGW_HAS_SECURE_API "_mingw.h" HAVE_MINGW_HAS_SECURE_API) 
+	if(NOT HAVE_MINGW_HAS_SECURE_API)
+		message(FATAL_ERROR "mingw must be compiled with --enable-secure-api")
+	endif()
 endif()
 
 include (CheckFunctionExists)

--- a/README
+++ b/README
@@ -9,3 +9,8 @@ libdshowcapture
    The biggest goal of this project is to eventually support as many devices as
    possible, as well as add more interesting features later on for improving
    performance.
+
+Load git submodules (required):
+
+   git submodule update --init
+

--- a/cmake/Modules/FindCXX11.cmake
+++ b/cmake/Modules/FindCXX11.cmake
@@ -1,0 +1,68 @@
+# - Finds if the compiler has C++11 support
+# This module can be used to detect compiler flags for using C++11, and checks
+# a small subset of the language.
+#
+# The following variables are set:
+#   CXX11_FLAGS - flags to add to the CXX compiler for C++11 support
+#   CXX11_FOUND - true if the compiler supports C++11
+#
+
+if(CXX11_FLAGS)
+    set(CXX11_FOUND TRUE)
+    return()
+endif()
+
+include(CheckCXXSourceCompiles)
+
+if(MSVC)
+    set(CXX11_FLAG_CANDIDATES
+	    " "
+        )
+else()
+    set(CXX11_FLAG_CANDIDATES
+        #gcc
+        "-std=gnu++11"
+        "-std=gnu++0x"
+        #Gnu and Intel Linux
+        "-std=c++11"
+        "-std=c++0x"
+        #Microsoft Visual Studio, and everything that automatically accepts C++11
+        " "
+        #Intel windows
+        "/Qstd=c++11"
+        "/Qstd=c++0x"
+        )
+endif()
+
+set(CXX11_TEST_SOURCE
+"
+int main()
+{
+    int n[] = {4,7,6,1,2};
+	int r;
+	auto f = [&](int j) { r = j; };
+	
+    for (auto i : n)
+        f(i);
+    return 0;
+}
+")
+
+foreach(FLAG ${CXX11_FLAG_CANDIDATES})
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(CXX11_FLAG_DETECTED CACHE)
+    message(STATUS "Try C++11 flag = [${FLAG}]")
+    check_cxx_source_compiles("${CXX11_TEST_SOURCE}" CXX11_FLAG_DETECTED)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(CXX11_FLAG_DETECTED)
+        set(CXX11_FLAGS_INTERNAL "${FLAG}")
+        break()
+    endif(CXX11_FLAG_DETECTED)
+endforeach(FLAG ${CXX11_FLAG_CANDIDATES})
+
+set(CXX11_FLAGS "${CXX11_FLAGS_INTERNAL}" CACHE STRING "C++11 Flags")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CXX11 DEFAULT_MSG CXX11_FLAGS)
+mark_as_advanced(CXX11_FLAGS)

--- a/source/dshow-enum.cpp
+++ b/source/dshow-enum.cpp
@@ -18,7 +18,15 @@
  */
 
 #include <stdlib.h>
+#include <thread>
+#if defined(_WIN32) && !defined(__WINPTHREADS_VERSION)
+#include "mingw.thread.h"
 #include <mutex>
+#include "mingw.mutex.h"
+#include "mingw.condition_variable.h"
+#else
+#include <mutex>
+#endif
 #include "dshow-enum.hpp"
 #include "dshow-formats.hpp"
 #include "log.hpp"

--- a/source/encoder.hpp
+++ b/source/encoder.hpp
@@ -26,7 +26,14 @@
 #include <string>
 #include <vector>
 #include <deque>
+#if defined(_WIN32) && !defined(__WINPTHREADS_VERSION)
+#include "mingw.thread.h"
 #include <mutex>
+#include "mingw.mutex.h"
+#include "mingw.condition_variable.h"
+#else
+#include <mutex>
+#endif
 using namespace std;
 
 struct EncodedData {

--- a/source/log.cpp
+++ b/source/log.cpp
@@ -35,7 +35,11 @@ void SetLogCallback(LogCallback callback, void *param)
 static void Log(LogType type, const wchar_t *format, va_list args)
 {
 	wchar_t str[4096];
+#ifdef HAVE_VSWPRINTF_S
 	vswprintf_s(str, 4096, format, args);
+#else
+    vswprintf(str, 4096, format, args);
+#endif
 
 	if (logCallback)
 		logCallback(type, str, logParam);


### PR DESCRIPTION
MXE (M cross environment) http://www.mxe.cc / https://github.com/mxe/mxe allows to cross-compile windows applications using mingw-w64. 

Basic changes are:
- use vswprintf with mingw or vswprintf_s with MSVC
- workaround the partial mutex implementation when gcc is configured with win32 threads in mxe (using https://github.com/meganz/mingw-std-threads as submodule)