### PR TITLE
win-dshow: Improve automatic audio device selection

### DIFF
--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -151,6 +151,7 @@ namespace DShow {
 
 	struct VideoDevice : DeviceId {
 		bool audioAttached = false;
+		bool separateAudioFilter = false;
 		std::vector<VideoInfo> caps;
 	};
 
@@ -188,6 +189,9 @@ namespace DShow {
 		 * (name/path memeber variables will be ignored)
 		 */
 		bool        useVideoDevice = false;
+
+		/** Use separate filter for audio */
+		bool        useSeparateAudioFilter = false;
 
 		/** Desired sample rate */
 		int         sampleRate = 0;

--- a/source/device.cpp
+++ b/source/device.cpp
@@ -513,7 +513,7 @@ bool HDevice::SetAudioConfig(AudioConfig *config)
 	if (!config)
 		return true;
 
-	if (!config->useVideoDevice &&
+	if (!config->useVideoDevice && !config->useSeparateAudioFilter &&
 	    config->name.empty() && config->path.empty()) {
 		Error(L"No audio device name or path specified");
 		return false;
@@ -527,6 +527,14 @@ bool HDevice::SetAudioConfig(AudioConfig *config)
 		}
 
 		filter = videoFilter;
+	} else if (config->useSeparateAudioFilter) {
+		bool success = GetDeviceAudioFilter(videoConfig.path.c_str(), &filter);
+		if (!success) {
+			Error(L"Corresponding audio device for '%s' not found",
+				videoConfig.path.c_str());
+			return false;
+		}
+
 	} else {
 		bool success = GetDeviceFilter(CLSID_AudioInputDeviceCategory,
 				config->name.c_str(), config->path.c_str(),

--- a/source/dshow-base.hpp
+++ b/source/dshow-base.hpp
@@ -71,4 +71,31 @@ HRESULT MapPinToPacketID(IPin *pin, ULONG packetID);
 
 wstring ConvertHRToEnglish(HRESULT hr);
 
+/**
+ * Get audio filter for the same device as the given video device path
+ */
+bool GetDeviceAudioFilter(const wchar_t *videoDevicePath,
+		IBaseFilter **audioCaptureFilter);
+bool GetDeviceAudioFilter(REFCLSID deviceClass,
+		const wchar_t *videoDevicePath, IBaseFilter **audioCaptureFilter);
+
+/** Returns true if device instance path is an Elgato USB or PCIe device */
+bool IsElgatoDevice(const wchar_t *videoDeviceInstancePath);
+
+/** Read property from moniker */
+HRESULT ReadProperty(IMoniker *moniker, const wchar_t *property,
+		wchar_t *value, int size);
+
+/** Parse device instance path from device path */
+HRESULT DevicePathToDeviceInstancePath(const wchar_t *devicePath,
+		wchar_t *deviceInstancePath, int size);
+
+/** Get device instance path of the parent of the given device. */
+HRESULT GetParentDeviceInstancePath(const wchar_t *deviceInstancePath,
+		wchar_t *parentDeviceInstancePath, int size);
+
+/** Get device instance path of the parent of the given audio capture device. */
+HRESULT GetAudioCaptureParentDeviceInstancePath(IMoniker *audioCapture,
+		wchar_t *parentDeviceInstancePath, int size);
+
 }; /* namespace DShow */


### PR DESCRIPTION
Implement automatic audio device selection for devices that use 2 
separate DirectShow filters for audio and video instead of having a 
single filter with audio and video output pins. Please note that this 
fix is currently only active for Elgato USB and PCIe devices 
(e.g. Cam Link, HD60 S, HD60 Pro, 4K60 Pro) to do not unintentionally 
change the behavior for any other devices (e.g. webcams).